### PR TITLE
CSS: Implement variadic constructor

### DIFF
--- a/include/bygg/CSS/element.hpp
+++ b/include/bygg/CSS/element.hpp
@@ -92,6 +92,14 @@ namespace bygg::CSS {
              * @param element The element to set
              */
             Element(const Element& element) = default;
+
+            /**             *
+             * @brief Construct a new Element object
+             * @param tag The tag of the element
+             * @param args The properties of the element
+             */
+            template <typename... Args> Element(const string_type& tag, Args&&... args) :
+                element(std::make_pair(tag, bygg::CSS::Properties(std::forward<Args>(args)...))) {};
             /**
              * @brief Construct a new Element object
              */

--- a/tests/CSS.cpp
+++ b/tests/CSS.cpp
@@ -144,6 +144,14 @@ void CSS::test_element() {
         REQUIRE(element2.get_properties().at(0).get_pair().second == "value");
         REQUIRE(element2.get_properties().at(1).get_pair().first == "key2");
         REQUIRE(element2.get_properties().at(1).get_pair().second == "value2");
+        
+        Element element3{"my_new_element", Property{"key", "value"}, Property{"key2", "value2"}};
+
+        REQUIRE(element3.get_tag() == "my_new_element");
+        REQUIRE(element3.get_properties().at(0).get_pair().first == "key");
+        REQUIRE(element3.get_properties().at(0).get_pair().second == "value");
+        REQUIRE(element3.get_properties().at(1).get_pair().first == "key2");
+        REQUIRE(element3.get_properties().at(1).get_pair().second == "value2");
     };
 
     const auto test_copy_section = []() {


### PR DESCRIPTION
CSS: Implement variadic constructor, removing the use of the `make_properties` call.