### PR TITLE
Parser: Implement feature replacing \n newline chars with spaces.

### DIFF
--- a/include/bygg/HTML/parser.hpp
+++ b/include/bygg/HTML/parser.hpp
@@ -17,6 +17,7 @@ namespace bygg::HTML::Parser {
         bool consider_whitespace{true}; /* Utilize whitespace to determine depth. Results may vary. */
         bool handle_inner_tags{true}; /* Handle tags inside text data. */
         bool assume_inner_tag_is_non_self_closing{true}; /* Assume inner tags are non-self-closing. */
+        bool replace_newlines{true}; /* Replace newlines with a single space. Usually does more good than harm, but disable if you want to keep newlines. */
     };
 
     /**

--- a/src/HTML/parser.cpp
+++ b/src/HTML/parser.cpp
@@ -64,9 +64,30 @@ bygg::HTML::Section bygg::HTML::Parser::parse_html_string(const string_type& htm
                         data.pop_back();
                     }
 
+                    if (data.find('\n') != string_type::npos && options.replace_newlines) {
+                        size_t pos = data.find('\n');
+
+                        while (pos != string_type::npos) {
+                            data.replace(pos, 1, " ");
+                            pos = data.find('\n');
+                        }
+                    }
+
                     current_section->push_back(Element(it.tag, it.properties, data, it.type));
                 } else {
-                    current_section->push_back(Element(it.tag, it.properties, it.data, it.type));
+                    if (it.data.find('\n') != string_type::npos && options.replace_newlines) {
+                        string_type data = it.data;
+                        size_t pos = data.find('\n');
+
+                        while (pos != string_type::npos) {
+                            data.replace(pos, 1, " ");
+                            pos = data.find('\n');
+                        }
+
+                        current_section->push_back(Element(it.tag, it.properties, data, it.type));
+                    } else {
+                        current_section->push_back(Element(it.tag, it.properties, it.data, it.type));
+                    }
                 }
             }
         }


### PR DESCRIPTION
Especially useful for input HTML that utilizes newlines, especially since it doesn't have any effect on the final document anyway.