### PR TITLE
HTML/element: Add support for ElementParameters

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,7 @@ set(PUBLIC_HEADERS
         include/bygg/HTML/tag.hpp
         include/bygg/HTML/type_enum.hpp
         include/bygg/HTML/find_enum.hpp
+        include/bygg/HTML/element_enum.hpp
         include/bygg/HTML/pseudocode_generator.hpp
         include/bygg/HTML/content_formatter.hpp
         include/bygg/bygg.hpp

--- a/include/bygg/HTML/HTML.hpp
+++ b/include/bygg/HTML/HTML.hpp
@@ -13,6 +13,7 @@
 #include <bygg/HTML/type_enum.hpp>
 #include <bygg/HTML/formatting_enum.hpp>
 #include <bygg/HTML/find_enum.hpp>
+#include <bygg/HTML/element_enum.hpp>
 #include <bygg/HTML/property.hpp>
 #include <bygg/HTML/properties.hpp>
 #include <bygg/HTML/element.hpp>

--- a/include/bygg/HTML/element.hpp
+++ b/include/bygg/HTML/element.hpp
@@ -12,6 +12,7 @@
 #include <bygg/HTML/type_enum.hpp>
 #include <bygg/HTML/tag.hpp>
 #include <bygg/HTML/properties.hpp>
+#include <bygg/HTML/element_enum.hpp>
 
 /**
  * @brief A namespace to represent HTML elements and documents
@@ -26,6 +27,7 @@ namespace bygg::HTML {
             Properties properties{};
             string_type data{};
             Type type{Type::Data};
+            ElementParameters params{_default_element_parameters};
         public:
             /**
              * @brief The npos value
@@ -38,28 +40,32 @@ namespace bygg::HTML {
              * @param properties The properties of the element
              * @param data The data of the element
              * @param type The close tag type.
+             * @param params The parameters of the element
              */
-            explicit Element(string_type tag, const Properties& properties, string_type data = {}, const Type& type = Type::Data) : tag(std::move(tag)), properties(properties), data(std::move(data)), type(type) {};
+            explicit Element(string_type tag, const Properties& properties, string_type data = {}, const Type& type = Type::Data, ElementParameters params = _default_element_parameters) : tag(std::move(tag)), properties(properties), data(std::move(data)), type(type), params(params) {};
             /**
              * @brief Construct a new Element object
              * @param tag The tag of the element
              * @param properties The properties of the element
              * @param data The data of the element
+             * @param params The parameters of the element
              */
-            explicit Element(const Tag tag, const Properties& properties, string_type data = {}) : tag(resolve_tag(tag).first), properties(properties), data(std::move(data)), type(resolve_tag(tag).second) {};
+            explicit Element(const Tag tag, const Properties& properties, string_type data = {}, ElementParameters params = _default_element_parameters) : tag(resolve_tag(tag).first), properties(properties), data(std::move(data)), type(resolve_tag(tag).second), params(params) {};
             /**
              * @brief Construct a new Element object
              * @param tag The tag of the element
              * @param data The data of the element
              * @param type The close tag type.
+             * @param params The parameters of the element
              */
-            explicit Element(string_type tag, string_type data = {}, const Type& type = Type::Data) : tag(std::move(tag)), data(std::move(data)), type(type) {};
+            explicit Element(string_type tag, string_type data = {}, const Type& type = Type::Data, ElementParameters params = _default_element_parameters) : tag(std::move(tag)), data(std::move(data)), type(type), params(params) {};
             /**
              * @brief Construct a new Element object
              * @param tag The tag of the element
              * @param data The data of the element
+             * @param params The parameters of the element
              */
-            explicit Element(const Tag tag, string_type data = {}) : tag(resolve_tag(tag).first), data(std::move(data)), type(resolve_tag(tag).second) {};
+            explicit Element(const Tag tag, string_type data = {}, ElementParameters params = _default_element_parameters) : tag(resolve_tag(tag).first), data(std::move(data)), type(resolve_tag(tag).second), params(params) {};
             /**
              * @brief Construct a new Element object
              * @param element The element to set
@@ -79,15 +85,17 @@ namespace bygg::HTML {
              * @param properties The properties of the element
              * @param data The data of the element
              * @param type The close tag type.
+             * @param params The parameters of the element
              */
-            void set(const string_type& tag, const Properties& properties, const string_type& data, Type type);
+            void set(const string_type& tag, const Properties& properties, const string_type& data, Type type, ElementParameters params = _default_element_parameters);
             /**
              * @brief Set the tag, properties, and data of the element
              * @param tag The tag of the element
              * @param properties The properties of the element
              * @param data The data of the element
+             * @param params The parameters of the element
              */
-            void set(Tag tag, const Properties& properties, const string_type& data);
+            void set(Tag tag, const Properties& properties, const string_type& data, ElementParameters params = _default_element_parameters);
             /**
              * @brief Set the tag of the element
              * @param tag The tag of the element
@@ -113,7 +121,11 @@ namespace bygg::HTML {
              * @param type The type of the element
              */
             void set_type(Type type);
-
+            /**
+             * @brief Set the parameters of the element
+             * @param params The parameters of the element
+             */
+            void set_params(ElementParameters params);
             /**
              * @brief Get the element in the form of an HTML tag.
              * @return string_type The tag of the element
@@ -171,6 +183,11 @@ namespace bygg::HTML {
              * @return Type The type of the element
              */
             [[nodiscard]] Type get_type() const;
+            /**
+             * @brief Get the parameters of the element
+             * @return ElementParameters The parameters of the element
+             */
+            [[nodiscard]] ElementParameters get_params() const;
             /**
              * @brief Clear the element
              */

--- a/include/bygg/HTML/element_enum.hpp
+++ b/include/bygg/HTML/element_enum.hpp
@@ -1,0 +1,34 @@
+/*
+ * bygg - Component-based HTML/CSS builder for C++
+ *
+ * Copyright 2024-2025 - Jacob Nilsson & contributors
+ * SPDX-License-Identifier: MIT
+ */
+#pragma once
+
+namespace bygg::HTML {
+    /**
+     * @brief Enum for Element() class
+     */
+    enum class ElementParameters {
+        Erase_Newlines = 1 << 0,
+        Erase_Tabs = 1 << 1,
+        Erase_Spaces = 1 << 2,
+        Erase_Multi_Spaces = 1 << 3,
+        Erase_All = Erase_Newlines | Erase_Tabs | Erase_Spaces | Erase_Multi_Spaces,
+        Erase_Default = Erase_Newlines | Erase_Tabs | Erase_Multi_Spaces,
+        Erase_None = ~Erase_All
+    };
+
+    inline ElementParameters operator|(ElementParameters lhs, ElementParameters rhs) {
+        using T = std::underlying_type_t<ElementParameters>;
+        return static_cast<ElementParameters>(static_cast<T>(lhs) | static_cast<T>(rhs));
+    }
+
+    inline bool operator&(ElementParameters lhs, ElementParameters rhs) {
+        using T = std::underlying_type_t<ElementParameters>;
+        return static_cast<T>(lhs) & static_cast<T>(rhs);
+    }
+
+    static constexpr ElementParameters _default_element_parameters = ElementParameters::Erase_Default;
+} // namespace bygg::HTML

--- a/tests/HTML.cpp
+++ b/tests/HTML.cpp
@@ -502,6 +502,17 @@ void HTML::test_element() {
 
         element.set_type(bygg::HTML::Type::Closing);
         REQUIRE(element.get<std::string>() == "</h1>");
+
+        Element element2(bygg::HTML::Tag::H1, R"(
+            This string has a lot of whitespace
+            and should be formatted as such
+        )", ElementParameters::Erase_None);
+
+        REQUIRE(element2.get<std::string>() == "<h1>\n            This string has a lot of whitespace\n            and should be formatted as such\n        </h1>");
+
+        element2.set_params(_default_element_parameters);
+
+        REQUIRE(element2.get<std::string>() == "<h1>This string has a lot of whitespace and should be formatted as such</h1>");
     };
 
     const auto test_builder = []() {


### PR DESCRIPTION
With this commit, the default behavior is to trim unnecessary characters automatically from an element's data parameter.

Your existing code should work perfectly, as the new parameter is optional, but note that if you're using string literals they may no longer function as you'd expect. The old behavior can be restored, fortunately.